### PR TITLE
HAD-6264: Reduce size of "geocoding" docker image

### DIFF
--- a/docker/geocoding/.dockerignore
+++ b/docker/geocoding/.dockerignore
@@ -1,4 +1,9 @@
 *
-!ggs
+!ggs/webapp
+!ggs/cli
+!ggs/resources/config
+!ggs/resources/lib
+!ggs/resources/bin/linux64
+!ggs/resources/application.properties
 !deploy-ggs.sh
 

--- a/docker/geocoding/Dockerfile
+++ b/docker/geocoding/Dockerfile
@@ -1,39 +1,46 @@
 # we are extending everything from tomcat:8.0 image ...
-FROM tomcat:8.5-alpine
-MAINTAINER pb
+FROM tomcat:8.5-alpine as deploy-ggs
 
-COPY ggs /usr/local/ggs
-
-RUN apk update -q
-RUN apk add -q dos2unix
-RUN apk -v --update add python py-pip parallel
-RUN pip install --upgrade pyasn1-modules awscli
-
-RUN apk add --update \
-    py-cffi \
-    py-cryptography \
-  && pip install --upgrade pip \
-  && apk add --virtual build-deps \
-    gcc \
-    libffi-dev \
-    python-dev \
-    linux-headers \
-    musl-dev \
-    openssl-dev \
-  && pip install gsutil \
-  && apk del build-deps \
-  && apk add --upgrade bc \
-  && rm -rf /var/cache/apk/*
-
-	
+COPY ggs /usr/local/ggs	
 COPY deploy-ggs.sh /usr/local/ggs/
 
 RUN dos2unix /usr/local/ggs/deploy-ggs.sh \
     && chmod 755 /usr/local/ggs/deploy-ggs.sh \
     && chmod 755 /usr/local/ggs/cli/cli.sh \
-    && /usr/local/ggs/cli/cli.sh deploy --c /usr/local/ggs/resources --d $CATALINA_HOME/webapps/geocode --l $CATALINA_HOME/logs/ --m WAR_EXTRACTED
+    && /usr/local/ggs/cli/cli.sh deploy --c /usr/local/ggs/resources --d $CATALINA_HOME/webapps/geocode --l $CATALINA_HOME/logs/ --m WAR_EXTRACTED \
+	&& rm -rf /usr/local/ggs/webapp 
 
+FROM tomcat:8.5-alpine
+MAINTAINER Precisely
+
+## Install AWS CLI and dos2unix
+RUN apk update -q \
+    && apk add --update \
+   	    dos2unix \
+		python \
+		py-pip \
+		parallel \
+    && pip install --upgrade pyasn1-modules awscli 
+
+## Install gsutil CLI	
+RUN apk add --update \
+       py-cffi \
+       py-cryptography \
+    && pip install --upgrade pip \
+    && apk add --virtual build-deps \
+       gcc \
+       libffi-dev \
+       python-dev \
+       linux-headers \
+       musl-dev \
+       openssl-dev \
+    && pip install gsutil \
+    && apk del build-deps \
+    && apk add --upgrade bc \
+    && rm -rf /var/cache/apk/* 
+
+## Copy configured ggs libraries from deploy-ggs stage
+COPY --from=deploy-ggs /usr/local/ggs /usr/local/ggs
+COPY --from=deploy-ggs $CATALINA_HOME/webapps/geocode $CATALINA_HOME/webapps/geocode
+	
 CMD ["/usr/local/ggs/deploy-ggs.sh"]
-
-
-

--- a/docker/geocoding/Dockerfile
+++ b/docker/geocoding/Dockerfile
@@ -13,20 +13,19 @@ RUN dos2unix /usr/local/ggs/deploy-ggs.sh \
 FROM tomcat:8.5-alpine
 MAINTAINER Precisely
 
-## Install AWS CLI and dos2unix
+## Install AWS CLI
 RUN apk update -q \
     && apk add --update \
-   	    dos2unix \
 		python \
 		py-pip \
 		parallel \
-    && pip install --upgrade pyasn1-modules awscli 
+	&& pip install --upgrade pip pyasn1-modules \	
+    && pip install awscli 
 
 ## Install gsutil CLI	
 RUN apk add --update \
        py-cffi \
        py-cryptography \
-    && pip install --upgrade pip \
     && apk add --virtual build-deps \
        gcc \
        libffi-dev \


### PR DESCRIPTION
Deleted unused content from GGS distribution and also reduced number of layers by merging multiple RUN statements.
To remove Geocode war file, we need to use multi-stage docker build.