### PR TITLE
Set max-count to 3 to prevent range errors

### DIFF
--- a/kubernetes/cluster/aks/MicrosoftAKSSetup.md
+++ b/kubernetes/cluster/aks/MicrosoftAKSSetup.md
@@ -34,7 +34,7 @@ az configure --defaults group=@RESOURCE_GROUP@
 ### Create the AKS cluster
 To create the cluster, use this command:   
 ``` 
-az aks create --name ggssample --attach-acr @ACR_REPOSITORY@ --enable-cluster-autoscaler --min-count 1 --max-count 2 --node-osdisk-type Managed --node-osdisk-size 100 --node-vm-size Standard_DS4_v2  --nodepool-labels node-app=ggs
+az aks create --name ggssample --attach-acr @ACR_REPOSITORY@ --enable-cluster-autoscaler --min-count 1 --max-count 3 --node-osdisk-type Managed --node-osdisk-size 100 --node-vm-size Standard_DS4_v2  --nodepool-labels node-app=ggs
 ```  
   
 ### Create a node pool for NGINX Ingress


### PR DESCRIPTION
``--min-count 1 --max-count 2`` settings do not work with Azure CLI as the default value for ``node-count`` is 3, which is outside the proposed range.

Azure CLI error: ``node-count is not in the range of min-count and max-count``